### PR TITLE
Update CI Configuration and Remove Unused Java Install Script

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,7 +1,7 @@
 prepare:
   steps:
     - name: Install java
-      command: nix-env -iA nixpkgs.jdk19
+      command: nix-env -iA nixpkgs.jdk22_headless
     - name: Maven generate sources
       command: JAVA_HOME="$(readlink -e $(type -p javac) | sed  -e 's/\/bin\/javac//g')" ./mvnw install generate-sources -DskipTests     
 test:

--- a/install-java.sh
+++ b/install-java.sh
@@ -1,7 +1,0 @@
-# install-java.sh
-cd /home/user
-if ! [ -d jdk-19.0.2 ]; then
-wget https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz
-tar -xvf openjdk-19.0.2_linux-x64_bin.tar.gz
-rm openjdk-19.0.2_linux-x64_bin.tar.gz
-fi


### PR DESCRIPTION
This pull request addresses two issues:

1. **Remove unused Java install script to avoid confusion for new users**
   - The script for installing Java was outdated and no longer necessary. Removing it will help prevent confusion for new users setting up the project.

2. **Update CI configuration to use the latest Java version**
   - The Continuous Integration (CI) configuration has been updated to use the latest Java version. This change resolves an error encountered during the prepare process:
   
     ```
     error: Package ‘openjdk-19-ga’ in /nix/store/2mm4yl8q2y88aqyi8ywrx7igihbsf1v0-nixpkgs/nixpkgs/pkgs/development/compilers/openjdk/19.nix:16 is marked as insecure, refusing to evaluate.
     ```

These changes ensure that the project dependencies are up to date and improve the overall setup experience for new users.

#### Changes:
- **Remove unused Java install script**
  - Deleted the outdated script to avoid confusion for new users.
- **Update CI configuration**
  - Updated CI to use the latest version of Java, fixing the build error related to the insecure package.

#### Testing:
- Verified that the CI pipeline runs successfully with the updated Java version.
- Confirmed that the project works without the removed Java install script.

Please review and merge this PR to improve the project's setup process and CI reliability.